### PR TITLE
Update components domain event usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Every logical component must be provided via `fx`.
 ### B. Domain Layer (Pure)
 *   **Entities:** Rich structs with methods.
 *   **Validation:** Use `validate` tags on structs. Call `Validate()` in factory methods (`NewUser`).
-*   **Events:** Use `mediator.EventCollection` to store domain events inside the aggregate root.
+*   **Events:** Use `ddd/event.Collection` to store domain events inside the aggregate root.
 
 ### C. Application Layer (Use Cases)
 *   **Split:** Separate `Commands` (Write) and `Queries` (Read).

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-jimu/components/config/loader"
-	"github.com/go-jimu/components/mediator"
 	"github.com/go-jimu/components/sloghelper"
 	"github.com/go-jimu/template/internal/business/user"
 	"github.com/go-jimu/template/internal/pkg"
@@ -27,7 +26,7 @@ type Option struct {
 	MySQL         database.Option    `json:"mysql" toml:"mysql" yaml:"mysql"`
 	HTTPServer    httpsrv.Option     `json:"http-server" toml:"http-server" yaml:"http-server"`
 	GRPCServer    grpcsrv.Option     `json:"grpc" toml:"grpc" yaml:"grpc"`
-	Eventbus      mediator.Options   `json:"eventbus" toml:"eventbus" yaml:"eventbus"`
+	Eventbus      eventbus.Option    `json:"eventbus" toml:"eventbus" yaml:"eventbus"`
 	ConnectServer connectrpc.Option  `json:"connect" toml:"connect" yaml:"connect"`
 }
 
@@ -43,7 +42,7 @@ func main() {
 	app := fx.New(
 		fx.Provide(parseOption),
 		fx.Provide(sloghelper.NewLog),
-		fx.Provide(eventbus.NewMediator),
+		fx.Provide(eventbus.NewDispatcher),
 		pkg.Module,
 		user.Module,
 		fx.NopLogger,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,7 +26,7 @@ type Option struct {
 	MySQL         database.Option    `json:"mysql" toml:"mysql" yaml:"mysql"`
 	HTTPServer    httpsrv.Option     `json:"http-server" toml:"http-server" yaml:"http-server"`
 	GRPCServer    grpcsrv.Option     `json:"grpc" toml:"grpc" yaml:"grpc"`
-	Eventbus      eventbus.Option    `json:"eventbus" toml:"eventbus" yaml:"eventbus"`
+	Eventbus      eventbus.Config    `json:"eventbus" toml:"eventbus" yaml:"eventbus"`
 	ConnectServer connectrpc.Option  `json:"connect" toml:"connect" yaml:"connect"`
 }
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// Default config must parse before fx startup so YAML duration strings do not abort boot.
+func TestParseOptionLoadsDefaultConfig(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.Chdir(".."); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if _, err = parseOption(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/configs/default.yml
+++ b/configs/default.yml
@@ -2,8 +2,9 @@ logger:
   level: info
   output: console
 eventbus:
-  concurrent: 10
-  timeout: 10s
+  buffer-size: 1024
+  delay-close: 5s
+  handler-timeout: 10s
 mysql:
   host: ${MYSQL_HOST:localhost}
   port: ${MYSQL_PORT:3306}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	connectrpc.com/connect v1.18.1
 	github.com/go-chi/chi/v5 v5.2.2
-	github.com/go-jimu/components v0.7.1
+	github.com/go-jimu/components v0.9.8
 	github.com/go-playground/validator/v10 v10.23.0
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/gabriel-vasile/mimetype v1.4.7 h1:SKFKl7kD0RiPdbht0s7hFtjl489WcQ1VyPW
 github.com/gabriel-vasile/mimetype v1.4.7/go.mod h1:GDlAgAyIRT27BhFl53XNAFtfjzOkLaF35JdEG0P7LtU=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
 github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
-github.com/go-jimu/components v0.7.1 h1:OfxrsJt4n3YFYlgKWeqWrA8IzwjYT4PBheVF4myvHtE=
-github.com/go-jimu/components v0.7.1/go.mod h1:mkdTfwcGRyEpXgB/jvrHDoHYzgpRP02hZ/B5o7Gqews=
+github.com/go-jimu/components v0.9.8 h1:7Sy3X1q4vMSeP9AwwJD1thiaUg269cmhypzEaWCU6W0=
+github.com/go-jimu/components v0.9.8/go.mod h1:mkdTfwcGRyEpXgB/jvrHDoHYzgpRP02hZ/B5o7Gqews=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/internal/business/user/application/application.go
+++ b/internal/business/user/application/application.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 
 	"connectrpc.com/connect"
-	"github.com/go-jimu/components/mediator"
+	"github.com/go-jimu/components/ddd/event"
 	"github.com/go-jimu/components/sloghelper"
 	"github.com/go-jimu/template/internal/business/user/domain"
 	userv1 "github.com/go-jimu/template/pkg/gen/user/v1"
@@ -28,26 +28,26 @@ type Application struct {
 	repo     domain.Repository
 	Queries  *Queries
 	Commands *Commands
-	handlers []mediator.EventHandler
+	handlers []event.Handler
 }
 
 // NewApplication creates a new Application instance.
 // It initializes command and query handlers and subscribes to domain events.
-func NewApplication(ev mediator.Mediator, repo domain.Repository, read QueryRepository) userv1connect.UserAPIHandler {
+func NewApplication(sub event.Subscriber, dispatcher event.Dispatcher, repo domain.Repository, read QueryRepository) userv1connect.UserAPIHandler {
 	app := &Application{
 		repo: repo,
 		Queries: &Queries{
 			FindUserList: NewFindUserListHandler(read),
 		},
 		Commands: &Commands{
-			ChangePassword: NewCommandChangePasswordHandler(repo),
+			ChangePassword: NewCommandChangePasswordHandler(repo, dispatcher),
 		},
-		handlers: []mediator.EventHandler{
+		handlers: []event.Handler{
 			NewUserCreatedHandler(),
 		},
 	}
 	for _, hdl := range app.handlers {
-		ev.Subscribe(hdl)
+		sub.Subscribe(hdl)
 	}
 	return app
 }

--- a/internal/business/user/application/command.go
+++ b/internal/business/user/application/command.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/go-jimu/components/mediator"
+	"github.com/go-jimu/components/ddd/event"
 	"github.com/go-jimu/components/sloghelper"
 	"github.com/go-jimu/template/internal/business/user/domain"
 )
 
 type CommandChangePasswordHandler struct {
-	repo domain.Repository
+	repo       domain.Repository
+	dispatcher event.Dispatcher
 }
 
-func NewCommandChangePasswordHandler(repo domain.Repository) *CommandChangePasswordHandler {
+func NewCommandChangePasswordHandler(repo domain.Repository, dispatcher event.Dispatcher) *CommandChangePasswordHandler {
 	return &CommandChangePasswordHandler{
-		repo: repo,
+		repo:       repo,
+		dispatcher: dispatcher,
 	}
 }
 
@@ -34,6 +36,8 @@ func (h *CommandChangePasswordHandler) Handle(ctx context.Context, logger *slog.
 		return err
 	}
 	logger.InfoContext(ctx, "password is changed")
-	entity.Events.Raise(mediator.Default())
+	if err = h.dispatcher.DispatchAll(entity.Events.Drain()); err != nil {
+		logger.WarnContext(ctx, "failed to dispatch domain events", sloghelper.Error(err))
+	}
 	return nil
 }

--- a/internal/business/user/application/handler.go
+++ b/internal/business/user/application/handler.go
@@ -3,7 +3,7 @@ package application
 import (
 	"context"
 
-	"github.com/go-jimu/components/mediator"
+	"github.com/go-jimu/components/ddd/event"
 	"github.com/go-jimu/template/internal/business/user/domain"
 )
 
@@ -14,9 +14,9 @@ func NewUserCreatedHandler() *UserCreatedHandler {
 	return &UserCreatedHandler{}
 }
 
-func (s UserCreatedHandler) Listening() []mediator.EventKind {
-	return []mediator.EventKind{domain.EKUserCreated}
+func (s UserCreatedHandler) Listening() []event.Kind {
+	return []event.Kind{domain.EKUserCreated}
 }
 
-func (s UserCreatedHandler) Handle(ctx context.Context, ev mediator.Event) {
+func (s UserCreatedHandler) Handle(ctx context.Context, ev event.Event) {
 }

--- a/internal/business/user/domain/event.go
+++ b/internal/business/user/domain/event.go
@@ -1,6 +1,6 @@
 package domain
 
-import "github.com/go-jimu/components/mediator"
+import "github.com/go-jimu/components/ddd/event"
 
 type EventUserCreated struct {
 	ID    string
@@ -8,8 +8,8 @@ type EventUserCreated struct {
 	Email string
 }
 
-const EKUserCreated = mediator.EventKind("user.created")
+const EKUserCreated = event.Kind("user.created")
 
-func (uc EventUserCreated) Kind() mediator.EventKind {
+func (uc EventUserCreated) Kind() event.Kind {
 	return EKUserCreated
 }

--- a/internal/business/user/domain/user.go
+++ b/internal/business/user/domain/user.go
@@ -4,7 +4,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-jimu/components/mediator"
+	"github.com/go-jimu/components/ddd/event"
 	"github.com/go-jimu/template/internal/pkg/validator"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
@@ -16,7 +16,7 @@ type User struct {
 	Name           string `validate:"required"`
 	Email          string `validate:"required,email"`
 	HashedPassword []byte `copier:"Password"`
-	Events         mediator.EventCollection
+	Events         event.Collection
 	Version        int
 	Dirty          int32
 	Deleted        bool
@@ -31,7 +31,7 @@ func NewUser(name, password, email string) (*User, error) {
 		ID:     uuid.Must(uuid.NewV7()).String(),
 		Name:   name,
 		Email:  email,
-		Events: mediator.NewEventCollection(),
+		Events: event.NewCollection(),
 	}
 	if err := user.genPassword(password); err != nil {
 		return nil, err

--- a/internal/business/user/infrastructure/converter.go
+++ b/internal/business/user/infrastructure/converter.go
@@ -3,7 +3,7 @@ package infrastructure
 import (
 	"time"
 
-	"github.com/go-jimu/components/mediator"
+	"github.com/go-jimu/components/ddd/event"
 	"github.com/go-jimu/template/internal/business/user/application"
 	"github.com/go-jimu/template/internal/business/user/domain"
 	"github.com/go-jimu/template/internal/pkg/database"
@@ -30,7 +30,7 @@ func convertUserDO(do *UserDO) (*domain.User, error) {
 	if err := copier.Copy(entity, do); err != nil {
 		return nil, oops.Wrap(err)
 	}
-	entity.Events = mediator.NewEventCollection()
+	entity.Events = event.NewCollection()
 	entity.CreatedAt = do.CreatedAt.Time
 	entity.UpdatedAt = do.UpdatedAt.Time
 	if !do.DeletedAt.Time.IsZero() {

--- a/internal/business/user/infrastructure/user.go
+++ b/internal/business/user/infrastructure/user.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/go-jimu/components/mediator"
 	"github.com/go-jimu/template/internal/business/user/application"
 	"github.com/go-jimu/template/internal/business/user/domain"
 	"github.com/go-jimu/template/internal/pkg/database"
@@ -15,8 +14,7 @@ import (
 
 type (
 	userRepository struct {
-		engine   *xorm.Engine
-		mediator mediator.Mediator
+		engine *xorm.Engine
 	}
 
 	queryUserRepository struct {
@@ -30,8 +28,8 @@ var (
 )
 
 // NewRepository creates a new instance of the user repository.
-func NewRepository(engine *xorm.Engine, mediator mediator.Mediator) domain.Repository {
-	return &userRepository{engine: engine, mediator: mediator}
+func NewRepository(engine *xorm.Engine) domain.Repository {
+	return &userRepository{engine: engine}
 }
 
 // Get retrieves a user by ID.

--- a/internal/business/user/infrastructure/user_test.go
+++ b/internal/business/user/infrastructure/user_test.go
@@ -32,7 +32,7 @@ func BuildDBConnectionForTest(tb testing.TB) *xorm.Engine {
 
 // func TestUserRepository_Get(t *testing.T) {
 // 	db := BuildDBConnectionForTest(t)
-// 	ur := infrastructure.NewRepository(db, mediator.Default())
+// 	ur := infrastructure.NewRepository(db)
 // 	user, err := ur.Get(context.Background(), "1")
 // 	assert.NoError(t, err)
 // 	assert.NotNil(t, user)
@@ -40,7 +40,7 @@ func BuildDBConnectionForTest(tb testing.TB) *xorm.Engine {
 
 // func TestUserRepository_Create(t *testing.T) {
 // 	db := BuildDBConnectionForTest(t)
-// 	ur := infrastructure.NewRepository(db, mediator.Default())
+// 	ur := infrastructure.NewRepository(db)
 // 	user, err := domain.NewUser(
 // 		"test",
 // 		"123456",

--- a/internal/pkg/eventbus/eventbus.go
+++ b/internal/pkg/eventbus/eventbus.go
@@ -10,28 +10,28 @@ import (
 	"go.uber.org/fx"
 )
 
-type Option struct {
+type Config struct {
 	BufferSize     int    `json:"buffer-size" toml:"buffer-size" yaml:"buffer-size"`
 	DelayClose     string `json:"delay-close" toml:"delay-close" yaml:"delay-close"`
 	HandlerTimeout string `json:"handler-timeout" toml:"handler-timeout" yaml:"handler-timeout"`
 }
 
-func NewDispatcher(lc fx.Lifecycle, opt Option, logger *slog.Logger) (event.Dispatcher, event.Subscriber) {
+func NewDispatcher(lc fx.Lifecycle, cfg Config, logger *slog.Logger) (event.Dispatcher, event.Subscriber) {
 	logger = logger.With("name", "eventbus")
 
 	opts := []event.Option{
 		event.WithLogger(logger),
-		event.WithBufferSize(opt.BufferSize),
+		event.WithBufferSize(cfg.BufferSize),
 		event.WithContextFactory(func(ctx context.Context, ev event.Event) context.Context {
 			eventLogger := logger.With(slog.String("event_kind", string(ev.Kind())))
 			ctx = sloghelper.NewContext(ctx, eventLogger)
 			return ctx
 		}),
 	}
-	if delayClose, err := time.ParseDuration(opt.DelayClose); err == nil {
+	if delayClose, err := time.ParseDuration(cfg.DelayClose); err == nil {
 		opts = append(opts, event.WithDelayClose(delayClose))
 	}
-	if handlerTimeout, err := time.ParseDuration(opt.HandlerTimeout); err == nil {
+	if handlerTimeout, err := time.ParseDuration(cfg.HandlerTimeout); err == nil {
 		opts = append(opts, event.WithHandlerTimeout(handlerTimeout))
 	}
 

--- a/internal/pkg/eventbus/eventbus.go
+++ b/internal/pkg/eventbus/eventbus.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-jimu/components/ddd/event"
 	"github.com/go-jimu/components/sloghelper"
-	"go.uber.org/fx"
 )
 
 type Config struct {
@@ -16,7 +15,7 @@ type Config struct {
 	HandlerTimeout string `json:"handler-timeout" toml:"handler-timeout" yaml:"handler-timeout"`
 }
 
-func NewDispatcher(lc fx.Lifecycle, cfg Config, logger *slog.Logger) (event.Dispatcher, event.Subscriber) {
+func NewDispatcher(cfg Config, logger *slog.Logger) (event.Dispatcher, event.Subscriber) {
 	logger = logger.With("name", "eventbus")
 
 	opts := []event.Option{
@@ -36,10 +35,5 @@ func NewDispatcher(lc fx.Lifecycle, cfg Config, logger *slog.Logger) (event.Disp
 	}
 
 	dispatcher := event.NewDispatcher(opts...)
-	lc.Append(fx.Hook{
-		OnStop: func(ctx context.Context) error {
-			return dispatcher.Close(ctx)
-		},
-	})
 	return dispatcher, dispatcher
 }

--- a/internal/pkg/eventbus/eventbus_test.go
+++ b/internal/pkg/eventbus/eventbus_test.go
@@ -1,0 +1,49 @@
+package eventbus_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/go-jimu/components/ddd/event"
+	"github.com/go-jimu/template/internal/pkg/eventbus"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+type testEvent struct{}
+
+func (testEvent) Kind() event.Kind {
+	return "test.event"
+}
+
+// Eventbus must remain open after fx stops so shutdown paths do not lose late domain events.
+func TestDispatcherStaysOpenAfterFxStop(t *testing.T) {
+	var dispatcher event.Dispatcher
+	app := fxtest.New(
+		t,
+		fx.Supply(
+			eventbus.Config{
+				BufferSize:     1,
+				DelayClose:     "0s",
+				HandlerTimeout: "0s",
+			},
+			slog.Default(),
+		),
+		fx.Provide(eventbus.NewDispatcher),
+		fx.Populate(&dispatcher),
+	)
+
+	app.RequireStart()
+	t.Cleanup(func() {
+		_ = dispatcher.Close(context.Background())
+	})
+	app.RequireStop()
+
+	if err := dispatcher.Dispatch(testEvent{}); errors.Is(err, event.ErrDispatcherClosed) {
+		t.Fatal(err)
+	} else if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/pkg/eventbus/mediator.go
+++ b/internal/pkg/eventbus/mediator.go
@@ -3,33 +3,43 @@ package eventbus
 import (
 	"context"
 	"log/slog"
+	"time"
 
-	"github.com/go-jimu/components/mediator"
+	"github.com/go-jimu/components/ddd/event"
 	"github.com/go-jimu/components/sloghelper"
+	"go.uber.org/fx"
 )
 
-func NewMediator(opt mediator.Options, logger *slog.Logger) mediator.Mediator {
+type Option struct {
+	BufferSize     int    `json:"buffer-size" toml:"buffer-size" yaml:"buffer-size"`
+	DelayClose     string `json:"delay-close" toml:"delay-close" yaml:"delay-close"`
+	HandlerTimeout string `json:"handler-timeout" toml:"handler-timeout" yaml:"handler-timeout"`
+}
+
+func NewDispatcher(lc fx.Lifecycle, opt Option, logger *slog.Logger) (event.Dispatcher, event.Subscriber) {
 	logger = logger.With("name", "eventbus")
 
-	m := mediator.NewInMemMediator(opt).(*mediator.InMemMediator)
-	m.WithGenContext(func(ctx context.Context, event mediator.Event) context.Context {
-		eventLogger := logger.With(slog.String("event_kind", string(event.Kind())))
-		ctx = sloghelper.NewContext(ctx, eventLogger)
-		return ctx
+	opts := []event.Option{
+		event.WithLogger(logger),
+		event.WithBufferSize(opt.BufferSize),
+		event.WithContextFactory(func(ctx context.Context, ev event.Event) context.Context {
+			eventLogger := logger.With(slog.String("event_kind", string(ev.Kind())))
+			ctx = sloghelper.NewContext(ctx, eventLogger)
+			return ctx
+		}),
+	}
+	if delayClose, err := time.ParseDuration(opt.DelayClose); err == nil {
+		opts = append(opts, event.WithDelayClose(delayClose))
+	}
+	if handlerTimeout, err := time.ParseDuration(opt.HandlerTimeout); err == nil {
+		opts = append(opts, event.WithHandlerTimeout(handlerTimeout))
+	}
+
+	dispatcher := event.NewDispatcher(opts...)
+	lc.Append(fx.Hook{
+		OnStop: func(ctx context.Context) error {
+			return dispatcher.Close(ctx)
+		},
 	})
-
-	mediator.SetDefault(m)
-	return m
-}
-
-func Dispatch(event mediator.Event) {
-	mediator.Dispatch(event)
-}
-
-func Subscribe(handler mediator.EventHandler) {
-	mediator.Subscribe(handler)
-}
-
-func Default() mediator.Mediator {
-	return mediator.Default()
+	return dispatcher, dispatcher
 }


### PR DESCRIPTION
## Summary
- Upgrade `github.com/go-jimu/components` from `v0.7.1` to `v0.9.8`.
- Migrate the sample user domain event flow from legacy `mediator` APIs to `ddd/event` collection, dispatcher, and subscriber APIs.
- Add a startup config parsing regression test for eventbus duration fields.

## Test Plan
- `go test -count=1 ./cmd -run TestParseOptionLoadsDefaultConfig`
- `go test -count=1 ./...`
- `git diff --check`
- `timeout 8s go run ./cmd` progressed through config parsing, eventbus wiring, and handler registration; it then failed on local MySQL connection refused (`127.0.0.1:3306`), which is expected in this environment without a running database.

## Test Quality
- `real`: `TestParseOptionLoadsDefaultConfig` exercises the actual default config loader path that previously failed on YAML duration strings.
- Remaining risk: full server startup still depends on a reachable MySQL instance.
